### PR TITLE
Improve corrected taxa ref file

### DIFF
--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -78,6 +78,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 31830	Plagiostoma devexa	(Desm.) Fuckel	species	Fungi	Plagiostoma devexum				
 32295	Ramularia gei	(A.G. Eliasson) Lindr.,1902	species	Fungi		(A.G.Eliasson) Höhn.			
 33740	Yarrowia lipolytica	(Wick., Kurtzman & E.A. Herrm.) Van der Walt & Arx, 1980	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2016
+33805	Bacidia brandii	Coppins & van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2021
 45964	Xanthophyta		phylum	Plantae				Chromista	
 45970	Myxomycota		phylum	Fungi			division		
 46177	Dama Linnaeus,	Linnaeus, 1758	species	Animalia	Dama				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -141,4 +141,4 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 51059	Malus sylvestris sylvestris		unranked		Malus sylvestris subsp. sylvestris		subspecies		
 51220	Adlafia minuscula minuscula		unranked		Adlafia minuscula var. minuscula		variety		
 51226	Gomphonema exilissimum	Lange-Bertalot & E.Reichardt, 1996 (Grunow)	species		Gomphonema exilissima				
-51679	Cyprinus carpio carpio		unranked				subspecies		
+51679	Cyprinus carpio carpio		unranked				subspecies		51652	Hylesinus fraxini	Panzer	species			Fabricius & J.C., 1801			

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -77,6 +77,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 31327	Phoma rijckholtii	Sacc.	species	Fungi	Phoma ryckholtii				
 31830	Plagiostoma devexa	(Desm.) Fuckel	species	Fungi	Plagiostoma devexum				
 32295	Ramularia gei	(A.G. Eliasson) Lindr.,1902	species	Fungi		(A.G.Eliasson) Höhn.			
+33740	Yarrowia lipolytica	(Wick., Kurtzman & E.A. Herrm.) Van der Walt & Arx, 1980	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2016
 45964	Xanthophyta		phylum	Plantae				Chromista	
 45970	Myxomycota		phylum	Fungi			division		
 46177	Dama Linnaeus,	Linnaeus, 1758	species	Animalia	Dama				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -135,6 +135,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50751	Pimplinae		genus				subfamily		
 50753	Pisces		genus				informal group		
 50788	Psocoptera		genus				order		
+50810	Ranunculus sgen. Batrachium		species		Batrachium	Gray (DC.)	subgenus		taxon rank improved, but invalid GBIF taxonomic rank
 50846	Scopariinae		genus				subfamily		
 50931	Tripleurospermum maritimum subsp. maritima	(L.) W.D.J.Koch	subspecies		Tripleurospermum maritimum subsp. maritimum	EMPTY			authorship refers to species
 50935	Tryphoninae		genus				subfamily		

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -92,6 +92,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 47269	Calycella syringa	(Linnaeus, 1758)	species	Fungi				Animalia	
 47316	Actinonema pachydermatum	Cobb, 1920	species	Fungi				Animalia	
 47319	Chromadorita nana	Lorenzen, 1973	species		Chromadorita nanna				
+48170	Coregonus lavaretus	Linnaeus, 1758	species	Animalia		Valenciennes, 1848			updated author from Linnaeus, 1758
 49622	Tychius polylineatus	Norman, H. Joy , 1932	species	Animalia		Schoenherr, 1835			updated author from Norman, H. Joy , 1932
 49641	Deporaus mannerheimii	(Hummel, 1823)	species	Animalia	Deporaus mannerheimi				
 49701	Cheirocratus sundevalli	(Rathke, 1843)	species		Cheirocratus sundevallii				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -80,6 +80,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 33740	Yarrowia lipolytica	(Wick., Kurtzman & E.A. Herrm.) Van der Walt & Arx, 1980	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2016
 33805	Bacidia brandii	Coppins & van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2021
 33847	Catillaria nigroisidiata	van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2018
+34241	Pyrenocollema chlorococcum	Aptroot & van den Boom	species	Fungi		EMPTY			removed authorship. Reported to GBIF Portal: #2017
 45964	Xanthophyta		phylum	Plantae				Chromista	
 45970	Myxomycota		phylum	Fungi			division		
 46177	Dama Linnaeus,	Linnaeus, 1758	species	Animalia	Dama				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -1,4 +1,16 @@
 id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_corrected	scientificnameauthorship_corrected	taxonranken_corrected	bim_kingdom_corrected	remark
+111	Psathyrella microrrhiza form. pumila	Kits van Wav.	forma	Fungi	Psathyrella microrhiza f. pumila				
+112	Psathyrella microrrhiza form. microrrhiza		forma	Fungi	Psathyrella microrhiza f. microrhiza				
+134	Russula heterophylla form. pseudoochroleuca	Romagn.	forma	Fungi	Russula heterophylla f. pseudo-ochroleuca	Romagn., 1962			updated author from Romagn.
+317	Cortinarius calochrous var. calochrous		variety	Fungi	Cortinarius callochrous var. callochrous				
+363	Debaryomyces hansenii var. fabryii	(M. Ota) Nakase & M. Suzuki, 1985	variety	Fungi	Debaryomyces hansenii var. fabryi				
+388	Emericella nidulans var. echinulata	(Fennell & Raper) Subram., 1955	variety	Fungi		Godeas			updated author from (Fennell & Raper) Subram., 1955
+489	Hygrocybe fornicata var. streptopus	(Fr.) Fr.	variety	Fungi		(Fr.) Arnolds			updated author from (Fr.) Fr.
+576	Lycoperdon perlatum var. bonordeni	(Massee) Perdeck	variety	Fungi		(Massee) Perdeck, 1950			updated author from (Massee) Perdeck
+629	Neosartorya fischeri var. glabra	(Fennell & Raper) Malloch & Cain	variety	Fungi		Fennell & Raper, 1973			updated author from (Fennell & Raper) Malloch & Cain
+645	Paxillus panuoides var. ionipus	Quél.	variety	Fungi		(Quél.) Tkalcec & Me			updated author from Quél.
+655	Peziza vesiculosa var. minor	(Sacc.) Grélet	variety	Fungi		Fr., 1822			udpate author from (Sacc.) Grélet
+848	Volvariella pusilla var. taylori	(Berk.) Boekhout	variety	Fungi	Volvariella pusilla var. taylorii				
 864	Teucrium chamaedrys germanicum	(F.Herm.) Rech.f.	subspecies	Plantae	Teucrium chamaedrys subsp. germanicum				
 887	Vicia tetrasperma gracilis	(DC.) Hook.f.	subspecies	Plantae	Vicia tetrasperma subsp. gracilis				
 1081	Sagina apetala erecta	(Hornem.) F.Herm.	subspecies	Plantae	Sagina apetala subsp. erecta				
@@ -9,15 +21,44 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 1110	Vulpia ciliata ciliata	Dumort.	subspecies	Plantae	Vulpia ciliata subsp. ciliata				
 1111	Montia fontana chondrosperma	Fenzl	subspecies	Plantae	Montia fontana subsp. chondrosperma				
 1117	Salix cinerea cinerea	L.	subspecies	Plantae	Salix cinerea subsp. cinerea				
-1312	doliolum		subspecies	Fungi	Leptosphaeria doliolum doliolum       				
+1312	doliolum		subspecies	Fungi	Leptosphaeria doliolum doliolum				
 1316	hoehnelii		subspecies	Fungi	Phoma hoehnelii hoehnelii				
+1389	Echiodon drummondi	Thompson, 1837	species	Animalia	Echiodon drummondii				
+1427	Arabis hirsuta	L.	species	Plantae		(L.) Scop.			
+1445	Atropa bella-donna	L.	species	Plantae	Atropa belladonna				
+2136	Phylloscopus sibilatrix	(Bechstein, 1793)	species	Animalia	Phylloscopus sibillatrix				
 2178	Priocnemis exaltata	(Fabricius, 1775)	species	Animalia	Priocnemis exaltatus				
+2248	Lecania cuprea	(A. Massal.) van den Boom & Coppins	species	Fungi		(A.Massal.) v.d.Bo			updated author from (A. Massal.) van den Boom & Coppins
 2251	Lecania naegelii	(Hepp) Diederich & van den Boom	species	Fungi		(Hepp) Diedrich & v.d.Boom			
+2258	Pholiota fusus	(Batsch) Singer	species	Fungi	Pholiota fusa				
+2346	Trisopterus esmarki	(Nilsson, 1855)	species	Animalia	Trisopterus esmarkii				
 2524	Barbatula barbatulus	(Linnaeus, 1758)	species	Animalia	Barbatula barbatula				
+2540	Trigloporus lastoviza	(Brunnich, 1768)	species	Animalia		(Bonnaterre, 1788)			updated author from (Brunnich, 1768)
+2565	Gymnocephalus cernuus	(Linnaeus, 1758)	species	Animalia	Gymnocephalus cernus				
+3050	Micarea confusa	Coppins & van den Boom	species	Fungi		Coppins & v.d.Boom			updated author from Coppins & van den Boom
+3646	Myotis daubentoni	(Kuhl, 1817)	species	Animalia	Myotis daubentonii				
+4186	Cortinarius cristallinus	Fr.	species	Fungi	Cortinarius crystallinus				
+4547	Cordyceps forquignoni	Quél.	species	Fungi	Cordyceps forquignonii				
+4624	Cortinarius lividoochraceus	(Berk.) Berk.	species	Fungi	Cortinarius livido-ochraceus				
+4710	Cystoderma terrei	(Berk. & Broome) Harm.	species	Fungi	Cystoderma terryi	(Berk. & Broome) Harmaja			
+4835	Entoloma phaeocyathus	Noordel.	species	Fungi	Entoloma phaeocyathum				
 4871	Flavoscypha cantharellus	(Fr.:Fr.) Harm.	species	Fungi	Flavoscypha cantharella				
+4940	Hebeloma birrus	(Fr.) Gillet	species	Fungi	Hebeloma birrum				
+5226	Mycena cyanorrhiza	Quél.	species	Fungi	Mycena cyanorhiza				
+5396	Selenaspora guernisaci	(P. Crouan & H. Crouan) R. Heim & Le Gal	species	Fungi	Selenaspora guernisacii				
+5439	Tricholoma colossum	(Fr.) Quél.	species	Fungi	Tricholoma colossus				
+5543	Callistosporium luteoolivaceum	(Berk. & M.A. Curtis) Singer	species	Fungi	Callistosporium luteo-olivaceum				
+5545	Calocybe incarnatobrunnea	(Gerhardt)	species	Fungi	Calocybe incarnatobrunneum	(Ew.Gerhardt) Krieglst., 2001			updated author from (Gerhardt)
+5573	Conocybe huysmanii	Watling	species	Fungi	Conocybe huijsmanii				
+5603	Uleiota planata	(L., 1761)	species	Animalia	Uleiota planatus	(Linnaeus, 1760)			updated from (L., 1761)
 5626	melanostomus (pallas,1811)	(pallas,1811)	species	Animalia	Neogobius melanostomus				
+5704	Craspedosoma rawlinsi	Leach, 1814	species	Animalia	Craspedosoma rawlinsii				
+5871	Platyarthrus hoffmannseggi	Brandt, 1833	species	Animalia	Platyarthrus hoffmannseggii				
 5926	Arthaldeus pascuellus	(Fallén, 1826)	species	Animalia	Arthaldeus pascuella				
 5944	Conosanus obsoletus	(Kirschbaum, 1858)	species	Animalia	Conosanus obsoleta				
+6012	Euscelis lineolatus	Brullé, 1832	species	Animalia	Euscelis lineolata				
+6015	Evacanthus acuminatus	(Fabricius, 1794)	species	Animalia	Evacanthus acuminata				
+6016	Evacanthus interruptus	(Linnaeus, 1758)	species	Animalia	Evacanthus interrupta				
 6252	Nothodelphax albocarinatus	(Stål, 1858)	species	Animalia	Nothodelphax albocarinata				
 6254	Oncodelphax pullulus	(Boheman, 1852)	species	Animalia	Oncodelphax pullula				
 6304	Luzulaspis sp.		species	Animalia	Luzulaspis		genus		
@@ -32,25 +73,41 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 13257	Gymnomus caesia	(Meigen, 1830)	species	Animalia	Gymnomus caesius				
 13551	Dicranomyia stigmatica	(Philippi, 1866)	species	Animalia		(Meigen, 1830)			updated author from (Philippi, 1866)
 14007	Exechia rufithorax	Van der Wulp, 1874	species	Animalia		Wulp, 1874			
+15464	Sphaerophoria rueppelli	(Wiedemann, 1830)	species	Animalia		(Wiedemann, 1830)			updated from (Wiedemann, 1830)
+15472	Sphiximorpha subsessilis	(Illiger in Rossi, 1807)	species	Animalia	Sphiximorpha subsessillis	(Illiger, 1807)			updated author from (Illiger in Rossi, 1807)
+15622	Dexiosoma caninum	(Fabricius, 1781)	species	Animalia	Dexiosoma canina				
+15646	Eriothrix rufomaculata	(De Geer, 1775)	species	Animalia	Eriothrix rufomaculatus	(De Geer, 1776)			updated from (De Geer, 1775)
+16017	Tipula confusa	Van der Wulp, 1883	species	Animalia		Wulp, 1883			updated from Van der Wulp, 1883
 16156	Anobium costatum	Arrag., 1830	species	Animalia	Anobium costatus				
 16239	Smicronyx reichii	(Gyll., 1836)	species	Animalia	Smicronyx reichei				
+17463	Phyllobius roboretanus	Desbrochers, J. , 1891	species	Animalia		Gredler, 1882			updated author from Desbrochers, J. , 1891
 17780	Datonychus arquatus	(Hbst., 1795)	species	Animalia	Datonychus arquata				
 17791	Trichapion simile	(Kirby, 1811)	species	Animalia	Betulapion simile				Updated from Trichapion simile
+18027	Agrypnus murina	(Linnaeus, 1758)	species	Animalia	Agrypnus murinus				
+18035	Ampedus pomorum	(Hbst., 1787)	species	Animalia		(Herbst, 1784)			
+18372	Brachypterus glaber	(Stephens, 1832)	species	Animalia		(Newman, 1834)			updated from Stephens, 1832
 18727	Bythinus burrelli	Denny, 1825	species	Animalia	Bythinus burrellii				
 18815	Macrosiagon sp.		species	Animalia	Macrosiagon		genus		
 18817	Apion rubiginosum	Balfour-Browne , 1944	species	Animalia		Grill, 1893			
 19540	Lomechusoides strumosa	(F., 1792)	species	Animalia	Lomechusoides strumosus				
 20176	Rhadicolepus alpestris	(Kolenati, 1848)	species	Animalia	Rhadicoleptus alpestris				
+20606	Ctenolepisma longicaudatum	Escherich, 1905	species	Animalia	Ctenolepisma longicaudata				
+20700	Crepis vesicaria	Thuill.	species	Plantae		L.			updated author from Thuill.: Crepis vesicaria var. taraxicifolia (Thuill.) Thell. is a synonym
 20710	Gnaphalium luteo-album	L.	species	Plantae	Gnaphalium luteoalbum				
 20918	Salicornia europaea	L.	species	Plantae		EMPTY			remove authorship. Reported to GBIFPortal: #2019
+21570	Poecilia reticulatus	Peters, 1859	species	Animalia	Poecilia reticulata				
 22047	Caryocolum marmoreum	(Haworth, 1828)	species	Animalia	Caryocolum marmorea				
+22507	Phyllonorycter kleemannella	(Fabricius, 1781)	species	Animalia	Phyllonorycter klemannella				
 23765	Motacilla yarrellii Gould,	Gould, 1837	subspecies	Animalia	Motacilla yarrellii				
+23778	Actitis macularius	(Linnaeus, 1766)	species	Animalia	Actitis macularia				
 24423	ephippius		species	Animalia	Parodontodynerus ephippius				
+24425	Polistes dominulus	(Christ, 1791)	species	Animalia	Polistes dominula				
 24618	Botrytella sp.		species	Chromista	Botrytella		genus		
 24622	Elachista sp.		species	Chromista	Elachista		genus		
 24643	Myriactula sp.		species	Chromista	Myriactula		genus		
 24711	Cystoseira baccata	(S.G. Gmelin) Greville	species	Chromista		(S.G.Gmelin) P.C.Silva, 1952			
 24718	Dasysiphonia sp.		species	Plantae	Dasysiphonia		genus		
+24767	Patella vulgata	Linnaeus, 1758	species	Fungi				Animalia	
 24802	Ophiocytium arbuscula	(A. Braun) Rabenhorst	species	Plantae	Ophiocytium arbusculum				
 24981	Vaucheria intermedia	Nordstedt	species	Plantae				Chromista	
 24985	Vaucheria medusa	Christensen	species	Plantae				Chromista	
@@ -60,32 +117,69 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 24990	Vaucheria pseudogeminata	Dangeard	species	Plantae				Chromista	
 24994	Vaucheria synandra	Woronin	species	Plantae				Chromista	
 24999	Vaucheria walzii	Rothert	species	Plantae				Chromista	
+25111	Myotis bechsteini	(Kuhl, 1817)	species	Animalia	Myotis bechsteinii				
+25112	Myotis brandti	(Eversmann, 1845)	species	Animalia	Myotis brandtii				
 26098	Peritrechus lundii	(Gmelin, 1790)	species	Animalia	Peritrechus lundi				
+26313	Polymerus nigrita	(Fallén, 1807)	species	Animalia	Polymerus nigritum				
+26401	Podops inuncta	(Fabricius, 1775)	species	Animalia	Podops inunctus	(J.C.Fabricius, 1775)			
+26721	Agaricus xanthoderma	Genev.	species	Fungi	Agaricus xanthodermus				
 26847	Arthrobotrys psychrophila	(Drechsler) M. Scholler, Hagedorn & A. Rubner, 1999	species	Fungi	Arthrobotrys psychrophilus				
 26928	Aspergillus koningi	Oudem.	species	Fungi	Aspergillus koningii				
+27176	Bulgaria inquinans	Pers.:Fr., 1822	species	Fungi		(Pers.) Fr.			updated author from Pers.:Fr., 1822
 27199	Calyptellacapula gibbosh		species		Calyptella capula				Not sure what to do with "gibbosh"
+27394	Cenangium acicolum	(Fuckel) Rehm	species	Fungi	Cenangium acicola				
 27627	Coniosporium piri	Oudem.	species	Fungi	Coniosporium pyri				
+27855	Corticium alboochraceum		species	Fungi	Corticium albo-ochraceum				
 28027	Crepidotus roseoornatus	Pöder & Ferrari	species	Fungi	Crepidotus roseo-ornatus				
+28312	Debaryomyces tyrocola		species	Fungi	Debaryomyces tyrocolus				
 28315	Dekkera bruxellensis	Van der Walt, 1964	species	Fungi		EMPTY			removed authorship. Rapported to GBIF: gbif/portal-feedback/#2014
+28505	Discostroma polymorpha	Brockmann	species	Fungi	Discostroma polymorphum				
 28659	Diaporthe rijckholti	(Westend.) Nitschke	species	Fungi	Diaporthe ryckholtii				
+28665	Diaporthe semiimmersa	Nitschke	species	Fungi	Diaporthe semi-immersa				
 28688	Dothichiza pityophila	(Corda) Petr.	species	Fungi	Dothichiza pithyophila				
+28905	Eurotium rubrum	Jos. König et al., 1901	species	Fungi		Thom & Church (Jos.König & al.)			updated author from Jos. König et al., 1901
+28964	Flammulaster ferruginea	(Maire ex Kühner) Watling	species	Fungi	Flammulaster ferrugineus				
+29149	Geopora semiimmersa	(P. Karst.) nom.prov.	species	Fungi	Geopora semi-immersa	(P.Karst.)			updated author from (P. Karst.) nom.prov.
 29173	Gloeosporium ulmicolum	Miles	species	Fungi	Gloeosporium ulmicola				
+29659	Hypocopra winterii	Oudem.	species	Fungi	Hypocopra winteri				
+29659	Hypocopra winterii	Oudem.	species	Fungi	Hypocopra winteri				
 29756	Kluyveromyces marxianus	(E.C. Hansen) Van der Walt 1971	species	Fungi		EMPTY			removed authorship. Rapported to GBIF: gbif/portal-feedback#2015
 29811	Lachnum soppitii	(Massee) Raitv.	species	Fungi	Lachnum soppittii				
+29943	Leucoagaricus wichanskyi	(Pilát) Singer	species	Fungi	Leucoagaricus wichanskyi				
+29943	Leucoagaricus wichanskyi	(Pilát) Singer	species	Fungi		(Pilát) Bon & Boiffard			upddated author from (Pilát) Singer
 30021	Leptosphaeria michoti	(Westend.) Sacc.	species	Fungi	Leptosphaeria michotii				
+30120	Lophiostoma aquatica	(J. Webster) Aptroot & K.D. Hyde	species	Fungi	Lophiostoma aquaticum				
+30125	Lophiostoma desmazierii	Sacc. & Speg.	species	Fungi	Lophiostoma desmazieri	Sacc. & Speg., 1878			updated author from Sacc. & Speg.
+30147	Lophodermium petiolicolum	Fuckel	species	Fungi	Lophodermium petiolicola				
 30154	Lodderomyces elongisporus	(Recca & Mrak) Van der Walt, 1971	species	Fungi		EMPTY			remove authorhsip
 30519	Myxosporium platanicolum	Ellis & Everh.	species	Fungi	Myxosporium platanicola				
+30682	Neottiella albo-cincta	(Berk. & M.A. Curtis) Sacc.	species	Fungi	Neottiella albocincta				
 31327	Phoma rijckholtii	Sacc.	species	Fungi	Phoma ryckholtii				
+31756	Pichia triangularis	M.T. Sm. & Batenburg-van der Vegte	species	Fungi		M.T.Sm. & Bat.Vegte, 1986			updated author from M.T. Sm. & Batenburg-van der Vegte
 31830	Plagiostoma devexa	(Desm.) Fuckel	species	Fungi	Plagiostoma devexum				
+31915	Poria sericeomollis	(Romell) D.V. Baxter, 1926	species	Fungi		Romell			udpated author from (Romell) D.V. Baxter, 1926
+31968	Psathyrella microrrhiza	(Lasch) Konrad & Maubl.	species	Fungi	Psathyrella microrhiza				
+32009	Pseudombrophila deerata	(P. Karst.) Seaver	species	Fungi	Pseudombrophila deerrata				
 32295	Ramularia gei	(A.G. Eliasson) Lindr.,1902	species	Fungi		(A.G.Eliasson) Höhn.			
+32412	Rozites caperata	(Pers.:Fr.) P. Karst.	species	Fungi	Rozites caperatus	(Pers.) P.Karst.			
+32537	Saccharomyces mangini		species	Fungi	Saccharomyces manginii				
+33021	Stephanoascus ciferrii	M.T. Sm., Van der Walt & Johannsen, 1976	species	Fungi		M.Smith & al.			updated author from M.T. Sm., Van der Walt & Johannsen, 1976
+33101	Stropharia rugoso-annulata	Farl. ex Murrill	species	Fungi	Stropharia rugosoannulata				
+33623	Valsa hoffmanni	Nitschke	species	Fungi	Valsa hoffmannii				
+33679	Velutarina rufoolivacea	(Alb. & Schwein.:Fr.) Korf	species	Fungi	Velutarina rufo-olivacea	(Alb. & Schwein.) Korf			
 33740	Yarrowia lipolytica	(Wick., Kurtzman & E.A. Herrm.) Van der Walt & Arx, 1980	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2016
 33805	Bacidia brandii	Coppins & van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2021
 33847	Catillaria nigroisidiata	van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2018
+33999	Micarea viridileprosa	Coppins & van den Boom	species	Fungi		Coppins & v.d.Boom			updated author from Coppins & van den Boom
+34239	Didymellopsis collematum		species	Fungi	Didymellopsis collemata				
 34241	Pyrenocollema chlorococcum	Aptroot & van den Boom	species	Fungi		EMPTY			removed authorship. Reported to GBIF Portal: #2017
+36404	Homoneura	Van der Wulp, 1891	genus	Animalia		Wulp, 1891			updated author from Van der Wulp, 1891
+40884	Trentepohlia		genus		Trentepholia				
 45964	Xanthophyta		phylum	Plantae				Chromista	
 45970	Myxomycota		phylum	Fungi			division		
 46177	Dama Linnaeus,	Linnaeus, 1758	species	Animalia	Dama				
 46188	Motacilla flavissima Blyth,	Blyth, 1834	subspecies	Animalia	Motacilla flavissima				
+46189	Saxicola torquata	Linnaeus, 1766	species	Animalia	Saxicola torquatus				
 46191	Ciliophora	Doflein, 1901	phylum	Animalia				Chromista	
 46261	Halictoxenos sp.		species	Animalia	Halictoxenos		genus		
 46756	Heteroptera		suborder	Animalia			order		
@@ -99,16 +193,25 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 49701	Cheirocratus sundevalli	(Rathke, 1843)	species		Cheirocratus sundevallii				
 49833	Cuon alpinus europaeus		species				subspecies		
 49842	Microtus malei	Schrank 1798	species			Hinton, 1927			updated author from Schrank 1798
+49939	Anas platyrhynchos f. domestica		forma	Animalia	Anas platyrhynchos f. domesticus				
 49942	Zygoribatula terricola	von der Hammen, 1952	species			der Hammen, 1952			
 50009	Mustela nivalis rixosa		species				subspecies		
 50013	Radix peregra		forma				species		
 50015	Equus caballus germanicus		species				subspecies		
 50048	Anser anser domesticus		species				forma		
 50092	Acari		genus				subclass		
+50097	Aceria cephalonea		species		Aceria cephaloneus				
+50102	Aceria macrochela		species		Aceria macrochelus				
 50103	Aceria macrorhyncha		species		Aceria macrorhynchus				
 50104	Aceria macrotricha		species		Aculops macrotrichus				https://github.com/inbo/ibge-bim-species/issues/30#issuecomment-497701301
+50106	Aceria tenella		species		Aceria tenellus				
+50124	Aethusa cynapium subsp. giganteum	Lej.	subspecies		Aethusa cynapium subsp. gigantea	(Lej.) P.D.Sell			
 50131	Agromyza idaeiana		family				species		
+50159	Andricus ostrea		species		Andricus ostreus				
+50170	Anomaloninae		genus				subfamily		
 50174	Aphidoidea		genus				superfamily		
+50185	Arabidopsis arenosa subsp. Arenosa	(L.) Lawalrée	subspecies		Arabidopsis arenosa subsp. arenosa				
+50188	Arctium minus subsp. minus	(Hill) Bernh.	subspecies		Arctium minus		species		Arctium minus var. minus and Arctium minus f. minus as synonyms
 50211	Atyaephyra desmaresti		species		Atyaephyra desmarestii				
 50252	Calamagrostis epigeios	(L.) Roth	species		Calamagrostis epigejos				
 50279	Ceraphronoidea		genus				superfamily		
@@ -120,6 +223,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50339	Crabroninae		genus				subfamily		
 50342	Cryptinae		genus				subfamily		
 50352	Cynipoidea		genus				superfamily		
+50395	Enoplagnatha		genus		Enoplognatha				
 50445	Forsythia		genus			Vahl			
 50466	Gomphocerinae		genus				subfamily		
 50485	Hexapoda		genus				subphylum		
@@ -133,15 +237,22 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50689	Orientus ishidae	Matsumura 1902	family				species		
 50697	Parasitica		genus				infraorder		
 50708	Pelophylax kl. esculentus		species	Animalia	Pelophylax esculentus				
+50744	Phytomyza conizae		species		Phytomyza conyzae				
 50751	Pimplinae		genus				subfamily		
 50753	Pisces		genus				informal group		
+50781	Psathyrella microrrhiza f. microrrhiza		forma		Psathyrella microrhiza f. microrhiza				
 50788	Psocoptera		genus				order		
 50810	Ranunculus sgen. Batrachium		species		Batrachium	Gray (DC.)	subgenus		taxon rank improved, but invalid GBIF taxonomic rank
 50846	Scopariinae		genus				subfamily		
+50882	Stenacis triradiata		species		Stenacis triradiatus	(Nalepa, 1892)			
 50931	Tripleurospermum maritimum subsp. maritima	(L.) W.D.J.Koch	subspecies		Tripleurospermum maritimum subsp. maritimum	EMPTY			authorship refers to species
 50935	Tryphoninae		genus				subfamily		
+50952	Vicia tetrasperma var. tetrasperma	(L.)Schreb.	variety		Vicia tetrasperma subsp. tetrasperma	(L.) Schreb.	subspecies		
 51057	Stellaria media media		unranked		Stellaria media subsp. media		subspecies		
 51059	Malus sylvestris sylvestris		unranked		Malus sylvestris subsp. sylvestris		subspecies		
 51220	Adlafia minuscula minuscula		unranked		Adlafia minuscula var. minuscula		variety		
 51226	Gomphonema exilissimum	Lange-Bertalot & E.Reichardt, 1996 (Grunow)	species		Gomphonema exilissima				
-51679	Cyprinus carpio carpio		unranked				subspecies		51652	Hylesinus fraxini	Panzer	species			Fabricius & J.C., 1801			
+51409	Orchestes fagi	Olivier	species			Stephens, 1831			updated author from Olivier
+51652	Hylesinus fraxini	Panzer	species			Fabricius & J.C., 1801			
+51671	Macrosaccus robiniella	Clemens, 1859	species		Macrosaccus robiniellus				
+51679	Cyprinus carpio carpio		unranked				subspecies		

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -106,6 +106,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50048	Anser anser domesticus		species				forma		
 50092	Acari		genus				subclass		
 50103	Aceria macrorhyncha		species		Aceria macrorhynchus				
+50104	Aceria macrotricha		species		Aculops macrotrichus				https://github.com/inbo/ibge-bim-species/issues/30#issuecomment-497701301
 50131	Agromyza idaeiana		family				species		
 50174	Aphidoidea		genus				superfamily		
 50211	Atyaephyra desmaresti		species		Atyaephyra desmarestii				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -42,6 +42,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 19540	Lomechusoides strumosa	(F., 1792)	species	Animalia	Lomechusoides strumosus				
 20176	Rhadicolepus alpestris	(Kolenati, 1848)	species	Animalia	Rhadicoleptus alpestris				
 20710	Gnaphalium luteo-album	L.	species	Plantae	Gnaphalium luteoalbum				
+20918	Salicornia europaea	L.	species	Plantae		EMPTY			remove authorship. Reported to GBIFPortal: #2019
 22047	Caryocolum marmoreum	(Haworth, 1828)	species	Animalia	Caryocolum marmorea				
 23765	Motacilla yarrellii Gould,	Gould, 1837	subspecies	Animalia	Motacilla yarrellii				
 24423	ephippius		species	Animalia	Parodontodynerus ephippius				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -65,6 +65,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 27199	Calyptellacapula gibbosh		species		Calyptella capula				Not sure what to do with "gibbosh"
 27627	Coniosporium piri	Oudem.	species	Fungi	Coniosporium pyri				
 28027	Crepidotus roseoornatus	Pöder & Ferrari	species	Fungi	Crepidotus roseo-ornatus				
+28315	Dekkera bruxellensis	Van der Walt, 1964	species	Fungi		EMPTY			removed authorship. Rapported to GBIF: gbif/portal-feedback/#2014
 28659	Diaporthe rijckholti	(Westend.) Nitschke	species	Fungi	Diaporthe ryckholtii				
 28688	Dothichiza pityophila	(Corda) Petr.	species	Fungi	Dothichiza pithyophila				
 29173	Gloeosporium ulmicolum	Miles	species	Fungi	Gloeosporium ulmicola				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -79,6 +79,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 32295	Ramularia gei	(A.G. Eliasson) Lindr.,1902	species	Fungi		(A.G.Eliasson) Höhn.			
 33740	Yarrowia lipolytica	(Wick., Kurtzman & E.A. Herrm.) Van der Walt & Arx, 1980	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2016
 33805	Bacidia brandii	Coppins & van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2021
+33847	Catillaria nigroisidiata	van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2018
 45964	Xanthophyta		phylum	Plantae				Chromista	
 45970	Myxomycota		phylum	Fungi			division		
 46177	Dama Linnaeus,	Linnaeus, 1758	species	Animalia	Dama				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -69,6 +69,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 28659	Diaporthe rijckholti	(Westend.) Nitschke	species	Fungi	Diaporthe ryckholtii				
 28688	Dothichiza pityophila	(Corda) Petr.	species	Fungi	Dothichiza pithyophila				
 29173	Gloeosporium ulmicolum	Miles	species	Fungi	Gloeosporium ulmicola				
+29756	Kluyveromyces marxianus	(E.C. Hansen) Van der Walt 1971	species	Fungi		EMPTY			removed authorship. Rapported to GBIF: gbif/portal-feedback#2015
 29811	Lachnum soppitii	(Massee) Raitv.	species	Fungi	Lachnum soppittii				
 30021	Leptosphaeria michoti	(Westend.) Sacc.	species	Fungi	Leptosphaeria michotii				
 30519	Myxosporium platanicolum	Ellis & Everh.	species	Fungi	Myxosporium platanicola				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -124,6 +124,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50466	Gomphocerinae		genus				subfamily		
 50485	Hexapoda		genus				subphylum		
 50494	Hydrachnidia		genus				unranked		
+50503	Hymenoscyphus subimberbis		species		Hymenoscyphus kathiae				synonym of Hymenoscyphus kathiae according to http://www.pilzflora-ehingen.de/pilzflora/arthtml/himberbis.php
 50521	Ichneumonoidea		genus				superfamily		
 50627	Microlepidoptera		genus				informal group		
 50657	Nematinae		genus				subfamily		

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -72,6 +72,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 29756	Kluyveromyces marxianus	(E.C. Hansen) Van der Walt 1971	species	Fungi		EMPTY			removed authorship. Rapported to GBIF: gbif/portal-feedback#2015
 29811	Lachnum soppitii	(Massee) Raitv.	species	Fungi	Lachnum soppittii				
 30021	Leptosphaeria michoti	(Westend.) Sacc.	species	Fungi	Leptosphaeria michotii				
+30154	Lodderomyces elongisporus	(Recca & Mrak) Van der Walt, 1971	species	Fungi		EMPTY			remove authorhsip
 30519	Myxosporium platanicolum	Ellis & Everh.	species	Fungi	Myxosporium platanicola				
 31327	Phoma rijckholtii	Sacc.	species	Fungi	Phoma ryckholtii				
 31830	Plagiostoma devexa	(Desm.) Fuckel	species	Fungi	Plagiostoma devexum				

--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -128,6 +128,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50753	Pisces		genus				informal group		
 50788	Psocoptera		genus				order		
 50846	Scopariinae		genus				subfamily		
+50931	Tripleurospermum maritimum subsp. maritima	(L.) W.D.J.Koch	subspecies		Tripleurospermum maritimum subsp. maritimum	EMPTY			authorship refers to species
 50935	Tryphoninae		genus				subfamily		
 51057	Stellaria media media		unranked		Stellaria media subsp. media		subspecies		
 51059	Malus sylvestris sylvestris		unranked		Malus sylvestris subsp. sylvestris		subspecies		


### PR DESCRIPTION
This PR improves the reference file `references/corrected_taxa.tsv`.
The reference file is still not complete, but it is better to push the improvements as discussed in several taxonomic issues.