### PR TITLE
Improve reference file corrected_taxa

### DIFF
--- a/references/corrected_taxa.tsv
+++ b/references/corrected_taxa.tsv
@@ -1,4 +1,6 @@
 id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_corrected	scientificnameauthorship_corrected	taxonranken_corrected	bim_kingdom_corrected	remark
+50	Galerina vittaeformis form. tetraspora		forma	Fungi	Galerina vittiformis f. tetraspora				
+51	Galerina vittaeformis form. bispora		forma	Fungi	Galerina vittiformis f. bispora	A.H.Sm. & Singer, 1964			Galerina vittiformis f. bispora is an etherotypic synonym: 2 taxa linked to same accepted taxon. The one with author A.H.Sm. & Singer, 1964 chosen as it is linked to occurrences, while taxon with author Arnolds, 1982 has no occurrences in GBIF
 111	Psathyrella microrrhiza form. pumila	Kits van Wav.	forma	Fungi	Psathyrella microrhiza f. pumila				
 112	Psathyrella microrrhiza form. microrrhiza		forma	Fungi	Psathyrella microrhiza f. microrhiza				
 134	Russula heterophylla form. pseudoochroleuca	Romagn.	forma	Fungi	Russula heterophylla f. pseudo-ochroleuca	Romagn., 1962			updated author from Romagn.
@@ -16,11 +18,11 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 1081	Sagina apetala erecta	(Hornem.) F.Herm.	subspecies	Plantae	Sagina apetala subsp. erecta				
 1085	Salsola kali kali	L.	subspecies	Plantae	Salsola kali subsp. kali				
 1087	Carex oederi oederi	Retz.	subspecies	Plantae	Carex oederi subsp. oederi				
-1099	Asparagus officinalis officinalis	L.	subspecies	Plantae	Asparagus officinalis subsp. officinalis				
 1105	Phleum pratense pratense	L.	subspecies	Plantae	Phleum pratense subsp. pratense				
 1110	Vulpia ciliata ciliata	Dumort.	subspecies	Plantae	Vulpia ciliata subsp. ciliata				
 1111	Montia fontana chondrosperma	Fenzl	subspecies	Plantae	Montia fontana subsp. chondrosperma				
 1117	Salix cinerea cinerea	L.	subspecies	Plantae	Salix cinerea subsp. cinerea				
+1311	Leptosphaeria arundinacea godini	(Desm.) Sacc.	subspecies	Fungi	Leptosphaeria arundinacea var. godinii		variety		
 1312	doliolum		subspecies	Fungi	Leptosphaeria doliolum doliolum				
 1316	hoehnelii		subspecies	Fungi	Phoma hoehnelii hoehnelii				
 1389	Echiodon drummondi	Thompson, 1837	species	Animalia	Echiodon drummondii				
@@ -53,6 +55,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 5603	Uleiota planata	(L., 1761)	species	Animalia	Uleiota planatus	(Linnaeus, 1760)			updated from (L., 1761)
 5626	melanostomus (pallas,1811)	(pallas,1811)	species	Animalia	Neogobius melanostomus				
 5704	Craspedosoma rawlinsi	Leach, 1814	species	Animalia	Craspedosoma rawlinsii				
+5762	Stigmatogaster subterraneus	(Shaw, 1789)	species	Animalia	Stigmatogaster subterranea				
 5871	Platyarthrus hoffmannseggi	Brandt, 1833	species	Animalia	Platyarthrus hoffmannseggii				
 5926	Arthaldeus pascuellus	(Fallén, 1826)	species	Animalia	Arthaldeus pascuella				
 5944	Conosanus obsoletus	(Kirschbaum, 1858)	species	Animalia	Conosanus obsoleta				
@@ -62,6 +65,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 6252	Nothodelphax albocarinatus	(Stål, 1858)	species	Animalia	Nothodelphax albocarinata				
 6254	Oncodelphax pullulus	(Boheman, 1852)	species	Animalia	Oncodelphax pullula				
 6304	Luzulaspis sp.		species	Animalia	Luzulaspis		genus		
+6367	Phaeostigma notata	(Fabricius, 1781)	species	Animalia	Phaeostigma notatum				
 7099	Chorebus resa	(Nixon, 1937)	species	Animalia	Chorebus resus				
 7105	Chorebus stenocera	(Thomson, 1895)	species	Animalia	Chorebus stenocerus				
 9700	obsoleta		species	Animalia	Andrena obsoleta				
@@ -80,7 +84,9 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 16017	Tipula confusa	Van der Wulp, 1883	species	Animalia		Wulp, 1883			updated from Van der Wulp, 1883
 16156	Anobium costatum	Arrag., 1830	species	Animalia	Anobium costatus				
 16239	Smicronyx reichii	(Gyll., 1836)	species	Animalia	Smicronyx reichei				
+17287	Henosepilachna argus	(Fourcr., 1762)	species	Animalia		(Geoffroy, 1785)			updated author from (Fourcr., 1762)
 17463	Phyllobius roboretanus	Desbrochers, J. , 1891	species	Animalia		Gredler, 1882			updated author from Desbrochers, J. , 1891
+17643	Curculio glandium	Desbrochers, J. , 1868	species	Animalia		Marsham, 1802			updated author from Desbrochers, J. , 1868
 17780	Datonychus arquatus	(Hbst., 1795)	species	Animalia	Datonychus arquata				
 17791	Trichapion simile	(Kirby, 1811)	species	Animalia	Betulapion simile				Updated from Trichapion simile
 18027	Agrypnus murina	(Linnaeus, 1758)	species	Animalia	Agrypnus murinus				
@@ -89,6 +95,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 18727	Bythinus burrelli	Denny, 1825	species	Animalia	Bythinus burrellii				
 18815	Macrosiagon sp.		species	Animalia	Macrosiagon		genus		
 18817	Apion rubiginosum	Balfour-Browne , 1944	species	Animalia		Grill, 1893			
+19080	Silvanus unidentatus	(Fabricius, 1792)	species	Animalia		(Olivier, 1790)			updated author from (Fabricius, 1792)
 19540	Lomechusoides strumosa	(F., 1792)	species	Animalia	Lomechusoides strumosus				
 20176	Rhadicolepus alpestris	(Kolenati, 1848)	species	Animalia	Rhadicoleptus alpestris				
 20606	Ctenolepisma longicaudatum	Escherich, 1905	species	Animalia	Ctenolepisma longicaudata				
@@ -97,6 +104,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 20918	Salicornia europaea	L.	species	Plantae		EMPTY			remove authorship. Reported to GBIFPortal: #2019
 21570	Poecilia reticulatus	Peters, 1859	species	Animalia	Poecilia reticulata				
 22047	Caryocolum marmoreum	(Haworth, 1828)	species	Animalia	Caryocolum marmorea				
+22198	Chloroclystis v-ata	(Haworth, 1809)	species	Animalia	Chloroclystis vata				
 22507	Phyllonorycter kleemannella	(Fabricius, 1781)	species	Animalia	Phyllonorycter klemannella				
 23765	Motacilla yarrellii Gould,	Gould, 1837	subspecies	Animalia	Motacilla yarrellii				
 23778	Actitis macularius	(Linnaeus, 1766)	species	Animalia	Actitis macularia				
@@ -119,9 +127,12 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 24999	Vaucheria walzii	Rothert	species	Plantae				Chromista	
 25111	Myotis bechsteini	(Kuhl, 1817)	species	Animalia	Myotis bechsteinii				
 25112	Myotis brandti	(Eversmann, 1845)	species	Animalia	Myotis brandtii				
+25113	Mesoplodon desirostris	(De Blainville, 1817)	species	Animalia	Mesoplodon densirostris	(Blainville, 1817)			updated acceptedname and author from (De Blainville, 1817)
 26098	Peritrechus lundii	(Gmelin, 1790)	species	Animalia	Peritrechus lundi				
 26313	Polymerus nigrita	(Fallén, 1807)	species	Animalia	Polymerus nigritum				
 26401	Podops inuncta	(Fabricius, 1775)	species	Animalia	Podops inunctus	(J.C.Fabricius, 1775)			
+26717	Agaricus silvaticus	Schaeff.:Fr.	species	Fungi	Agaricus sylvaticus	Schaeff.			updated acceptedname and author from Schaeff.:Fr.
+26718	Agaricus silvicola	(Vittad.) Peck	species	Fungi	Agaricus sylvicola	(Vittad.) Peck, 1872			updated acceptedname and author from (Vittad.) Peck
 26721	Agaricus xanthoderma	Genev.	species	Fungi	Agaricus xanthodermus				
 26847	Arthrobotrys psychrophila	(Drechsler) M. Scholler, Hagedorn & A. Rubner, 1999	species	Fungi	Arthrobotrys psychrophilus				
 26928	Aspergillus koningi	Oudem.	species	Fungi	Aspergillus koningii				
@@ -170,11 +181,13 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 33740	Yarrowia lipolytica	(Wick., Kurtzman & E.A. Herrm.) Van der Walt & Arx, 1980	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2016
 33805	Bacidia brandii	Coppins & van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2021
 33847	Catillaria nigroisidiata	van den Boom	species	Fungi		EMPTY			remove authorship. Reported to GBIFPortal: #2018
+33885	Collema tenax	(Sw.) Ach. em. Degel.	species	Fungi		(Sw.) Ach.			updated author from (Sw.) Ach. em. Degel.
 33999	Micarea viridileprosa	Coppins & van den Boom	species	Fungi		Coppins & v.d.Boom			updated author from Coppins & van den Boom
 34239	Didymellopsis collematum		species	Fungi	Didymellopsis collemata				
 34241	Pyrenocollema chlorococcum	Aptroot & van den Boom	species	Fungi		EMPTY			removed authorship. Reported to GBIF Portal: #2017
 36404	Homoneura	Van der Wulp, 1891	genus	Animalia		Wulp, 1891			updated author from Van der Wulp, 1891
 40884	Trentepohlia		genus		Trentepholia				
+45920	Hirudinea		class	Animalia			subclass		taxon rank improved, but invalid GBIF taxonomic rank
 45964	Xanthophyta		phylum	Plantae				Chromista	
 45970	Myxomycota		phylum	Fungi			division		
 46177	Dama Linnaeus,	Linnaeus, 1758	species	Animalia	Dama				
@@ -199,6 +212,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50013	Radix peregra		forma				species		
 50015	Equus caballus germanicus		species				subspecies		
 50048	Anser anser domesticus		species				forma		
+50069	Crustacea		species				subphylum		taxon rank improved, but invalid GBIF taxonomic rank
 50092	Acari		genus				subclass		
 50097	Aceria cephalonea		species		Aceria cephaloneus				
 50102	Aceria macrochela		species		Aceria macrochelus				
@@ -213,6 +227,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50185	Arabidopsis arenosa subsp. Arenosa	(L.) Lawalrée	subspecies		Arabidopsis arenosa subsp. arenosa				
 50188	Arctium minus subsp. minus	(Hill) Bernh.	subspecies		Arctium minus		species		Arctium minus var. minus and Arctium minus f. minus as synonyms
 50211	Atyaephyra desmaresti		species		Atyaephyra desmarestii				
+50230	Blattoptera		genus				order		
 50252	Calamagrostis epigeios	(L.) Roth	species		Calamagrostis epigejos				
 50279	Ceraphronoidea		genus				superfamily		
 50286	Chalcidoidea		genus				superfamily		
@@ -242,7 +257,7 @@ id	acceptedname	scientificnameauthorship	taxonranken	bim_kingdom	acceptedname_co
 50753	Pisces		genus				informal group		
 50781	Psathyrella microrrhiza f. microrrhiza		forma		Psathyrella microrhiza f. microrhiza				
 50788	Psocoptera		genus				order		
-50810	Ranunculus sgen. Batrachium		species		Batrachium	Gray (DC.)	subgenus		taxon rank improved, but invalid GBIF taxonomic rank
+50810	Ranunculus sgen. Batrachium		species		Batrachium	Gray (DC.)	subgenus		taxon rank improved, but invalid GBIF taxonomic rank, see https://github.com/inbo/ibge-bim-species/issues/31
 50846	Scopariinae		genus				subfamily		
 50882	Stenacis triradiata		species		Stenacis triradiatus	(Nalepa, 1892)			
 50931	Tripleurospermum maritimum subsp. maritima	(L.) W.D.J.Koch	subspecies		Tripleurospermum maritimum subsp. maritimum	EMPTY			authorship refers to species


### PR DESCRIPTION
Some taxa added to `references/corrected_taxa.tsv`.
Taxon Asparagus officinalis officinalis` removed as the corrected name proposed, `Asparagus officinalis subsp. officinalis` is not matched as well.